### PR TITLE
callback never gets called if lua file cannot be read

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function evaluateScript(redis, script_name, keys, args, callback) {
   }
 
   readScript(script_name, function (err, script) {
-    if (err) return err;
+    if (err) {
+      return callback(err)
+    }
 
     var sha = shaify(script);
     checkLoaded(redis, script_name, sha, function (err, exists) {


### PR DESCRIPTION
I have a problem with this package. I have messed up invoking `reval` with wrong path and my app just hangs there. Apparently when `readScript` fails, the callback never get called, `err` is just being returned into nowhere.